### PR TITLE
Parser location hardcoding support cause Fatal Errorr if called standard 

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -25,7 +25,7 @@ class View extends \Fuel\Core\View {
 	{
 		$extension	= pathinfo($file, PATHINFO_EXTENSION);
 		$class		= \Config::get('parser.extensions.'.$extension, get_called_class());
-		$file		= basename($file, '.'.$extension);
+		$file		= pathinfo($file, PATHINFO_DIRNAME).DS.pathinfo($file, PATHINFO_FILENAME);
 
 		// Class can be an array config
 		if (is_array($class))


### PR DESCRIPTION
Parser location hardcoding support cause Fatal Errorr if called standard view ... restored previous class
