### PR TITLE
Add template_dir to Smarty so {include} works as expected

### DIFF
--- a/classes/view/smarty.php
+++ b/classes/view/smarty.php
@@ -46,6 +46,7 @@ class View_Smarty extends \View {
 
 		// Parser
 		static::$_parser = new \Smarty();
+		static::$_parser->template_dir      = \Config::get('parser.View_Smarty.environment.template_dir', APPPATH.'views'.DS);
 		static::$_parser->compile_dir       = \Config::get('parser.View_Smarty.environment.compile_dir', APPPATH.'tmp'.DS.'Smarty'.DS.'templates_c'.DS);
 		static::$_parser->config_dir        = \Config::get('parser.View_Smarty.environment.config_dir', APPPATH.'tmp'.DS.'Smarty'.DS.'configs'.DS);
 		static::$_parser->cache_dir         = \Config::get('parser.View_Smarty.environment.cache_dir', APPPATH.'cache'.DS.'Smarty'.DS);


### PR DESCRIPTION
Using {include} in Smarty templates fails (if no absolute path is used) because no template directory was set for Smarty, so it does not know where to look for templates.

My solution is not perfect, as it does not support the cascading file system of the fuel View::factory-implementation, instead it only looks in the views-path of the application - but the only other solution (as far as I can see) would be to directly edit Smarty so Smarty calls View::factory for every {include}.
