### PR TITLE
Fixed a bug which ignores the default config of auto escaping values

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -19,6 +19,7 @@ class View extends \Fuel\Core\View {
 	public static function _init()
 	{
 		\Config::load('parser', true);
+		parent::_init();
 	}
 
 	public static function factory($file = null, array $data = null, $auto_encode = null)


### PR DESCRIPTION
If you configure the setting "auto_encode_view_data" to false in your app, you'll see that's not working if you're using parser package. That's because the package ignores the user configured value activated in _init method on core View class, and the package View class overwrite this method and doesn't activate the user configuration, so...
