### PR TITLE
Add extension support for Twig in Fuel Parser

### DIFF
--- a/classes/view/twig.php
+++ b/classes/view/twig.php
@@ -72,6 +72,13 @@ class View_Twig extends \View {
 			static::$_parser->setLexer($twig_lexer);
 		}
 
+		// Twig Extensions
+		$twig_extensions = \Config::get('parser.View_Twig.extensions', array());
+		foreach ($twig_extensions as $extension)
+		{
+			static::$_parser->addExtension(new $extension());
+		}
+
 		return static::$_parser;
 	}
 }

--- a/config/parser.php
+++ b/config/parser.php
@@ -76,8 +76,8 @@ return array(
 		 * Define any Twig extensions you wish to load here.
 		 */
 		'extensions' => array(
-			'\Twig_Extensions_Extension_Text',
-			'\Twig_Extensions_Extension_Debug',
+			//'\Twig_Extensions_Extension_Text',
+			//'\Twig_Extensions_Extension_Debug',
 			//'\Twig_Extensions_Extension_I18n',
 		),
 	),

--- a/config/parser.php
+++ b/config/parser.php
@@ -78,8 +78,6 @@ return array(
 		 */
 		'extensions' => array(
 			//'\Twig_Extensions_Extension_Text',
-			//'\Twig_Extensions_Extension_Debug',
-			//'\Twig_Extensions_Extension_I18n',
 		),
 	),
 

--- a/config/parser.php
+++ b/config/parser.php
@@ -70,8 +70,9 @@ return array(
 			'autoescape'           => false,
 			'optimizations'        => -1,
 		),
+
 		/**
-		 * Twig Extensions
+		 * Twig Extensions ( https://github.com/fabpot/Twig-extensions )
 		 *
 		 * Define any Twig extensions you wish to load here.
 		 */

--- a/config/parser.php
+++ b/config/parser.php
@@ -70,6 +70,16 @@ return array(
 			'autoescape'           => false,
 			'optimizations'        => -1,
 		),
+		/**
+		 * Twig Extensions
+		 *
+		 * Define any Twig extensions you wish to load here.
+		 */
+		'extensions' => array(
+			'\Twig_Extensions_Extension_Text',
+			'\Twig_Extensions_Extension_Debug',
+			//'\Twig_Extensions_Extension_I18n',
+		),
 	),
 
 	// DWOO ( http://wiki.dwoo.org/ )


### PR DESCRIPTION
Allows adding Twig extensions by defining them in parser config.
