### PR TITLE
Parser\View::factory() declaration incompatible with Fuel\Core\View::factory()

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -34,7 +34,7 @@ class View extends \Fuel\Core\View {
 		}
 	}
 
-	public static function factory($file = null, $data = null, $auto_encode = null)
+	public static function factory($file = null, array $data = null, $auto_encode = null)
 	{
 		$extension  = pathinfo($file, PATHINFO_EXTENSION);
 		$class      = \Config::get('parser.extensions.'.$extension, get_called_class());


### PR DESCRIPTION
I keep getting the following error in the logs when using Fuel 1.0.1.

```
Error - 2011-08-26 12:39:13 --> 2048 - Declaration of Parser\View::factory() should be compatible with that of Fuel\Core\View::factory() in /home/pbc/sites/rpm/fuel/packages/parser/classes/view.php on line 17
```

This commit seems to fix the problem.
