### PR TITLE
Fixed double dots in extension if used array config

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -62,7 +62,7 @@ class View extends \Fuel\Core\View {
 		// Class can be an array config
 		if (is_array($class))
 		{
-			$class['extension'] and $extension = $class['extension'];
+			$class['extension'] and $extension = preg_replace('/\./', '', $class['extension'], 1);
 			$class = $class['class'];
 		}
 


### PR DESCRIPTION
In array config the extension is specified with a dot before ( like '.extension' ).
That cause a double dots ( '..tpl' ) and a "not found" view error
