### PR TITLE
Extend Parser\View rather than \Fuel\Core\View

### DIFF
--- a/classes/view/dwoo.php
+++ b/classes/view/dwoo.php
@@ -18,7 +18,7 @@ use Dwoo;
 use Dwoo_Compiler;
 use Dwoo_Security_Policy;
 
-class View_Dwoo extends \View
+class View_Dwoo extends View
 {
 	protected static $_parser;
 	protected static $_parser_compiler;

--- a/classes/view/haml.php
+++ b/classes/view/haml.php
@@ -16,7 +16,7 @@ namespace Parser;
 
 use HamlParser;
 
-class View_Haml extends \View
+class View_Haml extends View
 {
 
 	protected static $_parser;

--- a/classes/view/jade.php
+++ b/classes/view/jade.php
@@ -16,7 +16,7 @@ namespace Parser;
 
 use Everzet\Jade;
 
-class View_Jade extends \View
+class View_Jade extends View
 {
 
 	protected static $_jade;

--- a/classes/view/markdown.php
+++ b/classes/view/markdown.php
@@ -14,7 +14,7 @@
 
 namespace Parser;
 
-class View_Markdown extends \View
+class View_Markdown extends View
 {
 
 	protected static $_parser;

--- a/classes/view/mustache.php
+++ b/classes/view/mustache.php
@@ -16,7 +16,7 @@ namespace Parser;
 
 use Mustache;
 
-class View_Mustache extends \View
+class View_Mustache extends View
 {
 	protected static $_parser;
 

--- a/classes/view/smarty.php
+++ b/classes/view/smarty.php
@@ -16,7 +16,7 @@ namespace Parser;
 
 use Smarty;
 
-class View_Smarty extends \View
+class View_Smarty extends View
 {
 	protected static $_parser;
 

--- a/classes/view/twig.php
+++ b/classes/view/twig.php
@@ -19,7 +19,7 @@ use Twig_Environment;
 use Twig_Loader_Filesystem;
 use Twig_Lexer;
 
-class View_Twig extends \View
+class View_Twig extends View
 {
 	protected static $_parser;
 	protected static $_parser_loader;


### PR DESCRIPTION
Each of the individual parser classes should be extending the
\Parser\View class rather than the \View class, in the case that the
Parser package is not loaded/called until after the first \View is
called.
