### PR TITLE
Putting the default value back. Fixes Issue #42

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -65,7 +65,7 @@ class View extends \Fuel\Core\View
 	public static function forge($file = null, $data = null, $auto_encode = null)
 	{
 		$extension = pathinfo($file, PATHINFO_EXTENSION);
-		$class     = \Config::get('parser.extensions.'.$extension);
+		$class     = \Config::get('parser.extensions.'.$extension, get_called_class());
 
 		// Only get rid of the extension if it is not an absolute file path
 		if ($file[0] !== '/' and $file[1] !== ':')


### PR DESCRIPTION
I've just updated the fuel core and packages on an existing site.

Then I started getting these errors https://gist.github.com/2149707

I have a class in a package `\Mobile\View` which extends the `\Parser\View` class and uses the `forge()` method.

Debugging it I discover `$class` is `null` for me, so I came here to see what had changed recently, and it appears the removal of the default value has caused a problem for me.

Is there any reason why the default value was removed? When I put it back it works again.
