### PR TITLE
Add support for the plugins_dir setting in Smarty.

### DIFF
--- a/classes/view/smarty.php
+++ b/classes/view/smarty.php
@@ -59,6 +59,7 @@ class View_Smarty extends \View
 		static::$_parser->compile_dir       = \Config::get('parser.View_Smarty.environment.compile_dir', APPPATH.'tmp'.DS.'Smarty'.DS.'templates_c'.DS);
 		static::$_parser->config_dir        = \Config::get('parser.View_Smarty.environment.config_dir', APPPATH.'tmp'.DS.'Smarty'.DS.'configs'.DS);
 		static::$_parser->cache_dir         = \Config::get('parser.View_Smarty.environment.cache_dir', APPPATH.'cache'.DS.'Smarty'.DS);
+		static::$_parser->plugins_dir       = array_merge(static::$_parser->plugins_dir, array(\Config::get('parser.View_Smarty.environment.plugins_dir', APPPATH.'cache'.DS.'Smarty'.DS)));
 
 		static::$_parser->caching           = \Config::get('parser.View_Smarty.environment.caching', false);
 		static::$_parser->cache_lifetime    = \Config::get('parser.View_Smarty.environment.cache_lifetime', 0);

--- a/classes/view/smarty.php
+++ b/classes/view/smarty.php
@@ -59,7 +59,7 @@ class View_Smarty extends \View
 		static::$_parser->compile_dir       = \Config::get('parser.View_Smarty.environment.compile_dir', APPPATH.'tmp'.DS.'Smarty'.DS.'templates_c'.DS);
 		static::$_parser->config_dir        = \Config::get('parser.View_Smarty.environment.config_dir', APPPATH.'tmp'.DS.'Smarty'.DS.'configs'.DS);
 		static::$_parser->cache_dir         = \Config::get('parser.View_Smarty.environment.cache_dir', APPPATH.'cache'.DS.'Smarty'.DS);
-		static::$_parser->plugins_dir       = array_merge(static::$_parser->plugins_dir, array(\Config::get('parser.View_Smarty.environment.plugins_dir', APPPATH.'cache'.DS.'Smarty'.DS)));
+		static::$_parser->plugins_dir       = array_merge(static::$_parser->plugins_dir, array(\Config::get('parser.View_Smarty.environment.plugins_dir', APPPATH.'smarty'.DS)));
 
 		static::$_parser->caching           = \Config::get('parser.View_Smarty.environment.caching', false);
 		static::$_parser->cache_lifetime    = \Config::get('parser.View_Smarty.environment.cache_lifetime', 0);

--- a/classes/view/smarty.php
+++ b/classes/view/smarty.php
@@ -59,7 +59,8 @@ class View_Smarty extends \View
 		static::$_parser->compile_dir       = \Config::get('parser.View_Smarty.environment.compile_dir', APPPATH.'tmp'.DS.'Smarty'.DS.'templates_c'.DS);
 		static::$_parser->config_dir        = \Config::get('parser.View_Smarty.environment.config_dir', APPPATH.'tmp'.DS.'Smarty'.DS.'configs'.DS);
 		static::$_parser->cache_dir         = \Config::get('parser.View_Smarty.environment.cache_dir', APPPATH.'cache'.DS.'Smarty'.DS);
-		static::$_parser->plugins_dir       = array_merge(static::$_parser->plugins_dir, array(\Config::get('parser.View_Smarty.environment.plugins_dir', APPPATH.'smarty'.DS)));
+		$plugins_dir 						= \Config::get('parser.View_Smarty.environment.plugins_dir', array());
+		static::$_parser->addPluginsDir($plugins_dir);
 
 		static::$_parser->caching           = \Config::get('parser.View_Smarty.environment.caching', false);
 		static::$_parser->cache_lifetime    = \Config::get('parser.View_Smarty.environment.cache_lifetime', 0);

--- a/config/parser.php
+++ b/config/parser.php
@@ -138,7 +138,7 @@ return array(
 			'compile_dir'       => APPPATH.'tmp'.DS.'Smarty'.DS.'templates_c'.DS,
 			'config_dir'        => APPPATH.'tmp'.DS.'Smarty'.DS.'configs'.DS,
 			'cache_dir'         => APPPATH.'cache'.DS.'Smarty'.DS,
-			'plugins_dir'       => APPPATH.'smarty'.DS,
+			'plugins_dir'       => array(),
 			'caching'           => false,
 			'cache_lifetime'    => 0,
 			'force_compile'     => false,

--- a/config/parser.php
+++ b/config/parser.php
@@ -138,6 +138,7 @@ return array(
 			'compile_dir'       => APPPATH.'tmp'.DS.'Smarty'.DS.'templates_c'.DS,
 			'config_dir'        => APPPATH.'tmp'.DS.'Smarty'.DS.'configs'.DS,
 			'cache_dir'         => APPPATH.'cache'.DS.'Smarty'.DS,
+			'plugins_dir'       => APPPATH.'cache'.DS.'Smarty'.DS,
 			'caching'           => false,
 			'cache_lifetime'    => 0,
 			'force_compile'     => false,

--- a/config/parser.php
+++ b/config/parser.php
@@ -138,7 +138,7 @@ return array(
 			'compile_dir'       => APPPATH.'tmp'.DS.'Smarty'.DS.'templates_c'.DS,
 			'config_dir'        => APPPATH.'tmp'.DS.'Smarty'.DS.'configs'.DS,
 			'cache_dir'         => APPPATH.'cache'.DS.'Smarty'.DS,
-			'plugins_dir'       => APPPATH.'cache'.DS.'Smarty'.DS,
+			'plugins_dir'       => APPPATH.'smarty'.DS,
 			'caching'           => false,
 			'cache_lifetime'    => 0,
 			'force_compile'     => false,


### PR DESCRIPTION
View_Smarty exposes a bunch of options but not plugins_dir.  This is necessary to get custom plugins working with Smarty.

I'm currently running the egregious hack below in the after method of my BaseController.  Save me from it? :)

```
    // After View_Smarty in fuel is patched to allow setting of a
    // plugins_dir in config we won't need to do it like this.
    if (is_object($this->canvas)) {
        $rc = new \ReflectionClass($this->canvas);
        if ($rc->hasMethod('parser')) {
            $parser = $this->canvas->parser();
        } elseif ($rc->hasProperty('_view')) {
            $parser = $this->canvas->_view->parser();
        } else {
            throw new YokoException("Unable to initialize Smarty i18n plugin.");
        }
        $smartyParam = 'plugins_dir';
        $ourPluginsDir = APPPATH . '/smarty';
        $pluginsDir = array_merge($parser->$smartyParam, [$ourPluginsDir]);
        $parser->$smartyParam = $pluginsDir;
    }
```
