### PR TITLE
Fixed searched paths for modules with Twig and removed paths duplicated

### DIFF
--- a/classes/view/twig.php
+++ b/classes/view/twig.php
@@ -42,8 +42,14 @@ class View_Twig extends \View
 
 		// Twig Loader
 		$views_paths = \Config::get('parser.View_Twig.views_paths', array(APPPATH . 'views'));
+
+		foreach ($this->active_request->get_paths() as $path)
+		{
+			array_unshift($views_paths, $path.'views');
+		}
+
 		array_unshift($views_paths, pathinfo($file, PATHINFO_DIRNAME));
-		static::$_parser_loader = new Twig_Loader_Filesystem($views_paths);
+		static::$_parser_loader = new Twig_Loader_Filesystem(array_unique($views_paths, SORT_STRING));
 
 		if ( ! empty($global_data))
 		{


### PR DESCRIPTION
<b>I'm not sure if this is the best method to fix the problem.</b>

I will try to explain the problem using an example :

<pre>
// REQUEST : Open admin/auth/login.html

// FOLDERS
// ---------------------------------------------------------
app/
    ...
    modules/
        module1/
            views/
                admin/
                    auth/
                        login.twig
                        forgot.twig
                    base.twig
                ...
// ---------------------------------------------------------


// auth/login.twig (VIEW NOT FOUND)
// ---------------------------------------------------------
{% extends 'admin/base.twig' %}

{% block contents %}
Login page
{% endblock %}
// ---------------------------------------------------------


// BEFORE : Searched paths (Parser/classes/view/twig.php line 45)
/app/modules/module1/views/admin/auth,
/app/views

// FIX : Add main Module's Views paths to searched paths

// AFTER : Searched paths
 /app/modules/module1/views/admin/auth
 /app/modules/module1/views
 /app/views
</pre>


Suggestions?
