### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simply add `parser` to your config.php `always_loaded.packages` config option.
 ## Included Parsers
 
 * Mustache - A lightweight, yet powerful templating library.
-* SimpleTags - A library released by Dan Horrigan for basic template tag usage.
+* Markdown - A PHP version of Markdown by Michael Fortin.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simply add `parser` to your config.php `always_loaded.packages` config option.
 ## Included Parsers
 
 * Mustache - A lightweight, yet powerful templating library.
-* Markdown - A PHP version of Markdown by Michael Fortin.
+* Markdown - A PHP version of Markdown by Michel Fortin.
 
 ## Usage
 


### PR DESCRIPTION
Adjusted the Readme to reflect the fact that SimpleTags is no longer included, but was replaced with Markdown.
