### PR TITLE
Changed View forge to allow setting filename later

### DIFF
--- a/classes/view.php
+++ b/classes/view.php
@@ -53,11 +53,22 @@ class View extends \Fuel\Core\View
 	 */
 	public static function forge($file = null, $data = null, $auto_encode = null)
 	{
-		$extension = pathinfo($file, PATHINFO_EXTENSION);
-		$class     = \Config::get('parser.extensions.'.$extension, get_called_class());
+		$class = null;
+
+		if ($file !== null)
+		{
+			$extension = pathinfo($file, PATHINFO_EXTENSION);
+
+			$class = \Config::get('parser.extensions.'.$extension, null);
+		}
+		
+		if ($class === null)
+		{
+			$class = get_called_class();
+		}
 
 		// Only get rid of the extension if it is not an absolute file path
-		if ($file[0] !== '/' and $file[1] !== ':')
+		if ($file !== null and $file[0] !== '/' and $file[1] !== ':')
 		{
 			$file = $extension ? preg_replace('/\.'.preg_quote($extension).'$/i', '', $file) : $file;
 		}
@@ -87,11 +98,14 @@ class View extends \Fuel\Core\View
 
 		$view = new $class(null, $data, $auto_encode);
 
-		// Set extension when given
-		$extension and $view->extension = $extension;
-
-		// Load the view file
-		$view->set_filename($file);
+		if ($file !== null)
+		{
+			// Set extension when given
+			$extension and $view->extension = $extension;
+			
+			// Load the view file
+			$view->set_filename($file);
+		}
 
 		return $view;
 	}


### PR DESCRIPTION
**So you can do (new functionality):**

``` php
$view = View_Twig::forge();
$view->set_filename('filename');
```

**Or do (existing functionality):**

``` php
$view = View_Twig::forge('filename');
$view2 = View::forge('filename.twig');
```

**Doesn't conflict with default fuel core either:**

``` php
$view = View::forge('errors/production');
```

This matches the core fuel View class more.
