### PR TITLE
1.6/mthaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ View::forge('example.mustache');
 // load a Twig template, will load and parse app/views/example.twig
 View::forge('example.twig');
 
+// load a Hybrid Haml / Twig template, ATTENTION: this one expects app/views/example.twig and {% haml %} code at the top of the view
+View::forge('example.mthaml');
+
 // load a Jade template, will load and parse app/views/example.jade
 View::forge('example.jade');
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ View::forge('example.dwoo');
 
 Only Markdown is included. While many other drivers are included, their libraries are not and are by default.
 
-Mustache, Twig and Smarty should be installed via Composer. Simply add the libraries to your project's `composer.json` then run `php composer.phar install`:
+Mustache, Twig, MtHaml and Smarty should be installed via Composer. Simply add the libraries to your project's `composer.json` then run `php composer.phar install`:
 
 ```json
 {
     "require": {
         "mustache/mustache" : "*",
         "smarty/smarty" : "*",
-        "twig/twig" : "*"
+        "twig/twig" : "*",
+        "mthaml/mthaml": "*"
     }
 }
 ```

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -21,6 +21,7 @@ Autoloader::add_classes(array(
 	'Parser\\View_Markdown'    => __DIR__.'/classes/view/markdown.php',
 	'Parser\\View_SimpleTags'  => __DIR__.'/classes/view/simpletags.php',
 	'Parser\\View_Twig'        => __DIR__.'/classes/view/twig.php',
+	'Parser\\View_HamlTwig'    => __DIR__.'/classes/view/hamltwig.php',
 	'Parser\\Twig_Fuel_Extension' => __DIR__.'/classes/twig/fuel/extension.php',
 	'Parser\\View_Jade'        => __DIR__.'/classes/view/jade.php',
 	'Parser\\View_Haml'        => __DIR__.'/classes/view/haml.php',

--- a/classes/view/hamltwig.php
+++ b/classes/view/hamltwig.php
@@ -65,9 +65,7 @@ class View_HamlTwig extends View_Twig {
 		// Twig Loader
 		$views_paths = \Config::get('parser.View_Twig.views_paths', array(APPPATH . 'views'));
 		array_unshift($views_paths, pathinfo($file, PATHINFO_DIRNAME));
-		
-		$filesyst = new Twig_Loader_Filesystem($views_paths);
-		
+				
 		if ( ! empty($global_data))
 		{
 			foreach ($global_data as $key => $value)
@@ -81,6 +79,8 @@ class View_HamlTwig extends View_Twig {
 			static::parser();
 		}
 		
+		// Set the HtHaml Twig loader
+		$filesyst = new Twig_Loader_Filesystem($views_paths);
 		static::$_parser_loader = new MtHaml\Support\Twig\Loader(static::$_environment, $filesyst);
 		
 		$twig_lexer = new Twig_Lexer(static::$_parser, static::$_twig_lexer_conf);

--- a/classes/view/hamltwig.php
+++ b/classes/view/hamltwig.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Fuel
+ *
+ * Fuel is a fast, lightweight, community driven PHP5 framework.
+ *
+ * @package    Fuel
+ * @version    1.5
+ * @author     Fuel Development Team
+ * @license    MIT License
+ * @copyright  2010 - 2013 Fuel Development Team
+ * @link       http://fuelphp.com
+ */
+
+namespace Parser;
+
+use Twig_Autoloader;
+use Twig_Environment;
+use Twig_Loader_Filesystem;
+use Twig_Lexer;
+use MtHaml;
+
+class View_HamlTwig extends View_Twig {
+	
+	protected static $_environment;
+	
+	/**
+	 * @access public
+	 * @static
+	 * @return void
+	 */
+	public static function _init()
+	{		
+		// Include View_HamlTwig file(s) defined in config.
+		$includes = \Config::get('parser.View_Twig.include');
+		
+		foreach ((array)$includes as $include)
+		{
+			require $include;
+			static::$loaded_files[$include] = true;
+		}
+		
+		parent::_init();
+		
+		MtHaml\Autoloader::register();
+		
+	}
+	
+	/**
+	 * We Override the parser Loader here
+	 * 
+	 * @access protected
+	 * @static
+	 */
+	protected function process_file($file_override = false)
+	{
+		$file = $file_override ?: $this->file_name;
+
+		$local_data  = $this->get_data('local');
+		$global_data = $this->get_data('global');
+
+		// Extract View name/extension (ex. "template.twig")
+		$view_name = pathinfo($file, PATHINFO_BASENAME);
+
+		// Twig Loader
+		$views_paths = \Config::get('parser.View_Twig.views_paths', array(APPPATH . 'views'));
+		array_unshift($views_paths, pathinfo($file, PATHINFO_DIRNAME));
+		
+		$filesyst = new Twig_Loader_Filesystem($views_paths);
+		
+		if ( ! empty($global_data))
+		{
+			foreach ($global_data as $key => $value)
+			{
+				static::parser()->addGlobal($key, $value);
+			}
+		}
+		else
+		{
+			// Init the parser if you have no global data
+			static::parser();
+		}
+		
+		static::$_parser_loader = new MtHaml\Support\Twig\Loader(static::$_environment, $filesyst);
+		
+		$twig_lexer = new Twig_Lexer(static::$_parser, static::$_twig_lexer_conf);
+		static::$_parser->setLexer($twig_lexer);
+		//\Debug::dump(static::parser()); exit();
+		try
+		{
+			return static::parser()->render($view_name, $local_data);
+		}
+		catch (\Exception $e)
+		{
+			// Delete the output buffer & re-throw the exception
+			ob_end_clean();
+			throw $e;
+		}
+	}
+	
+	/**
+	 * @access public
+	 * @static
+	 * @return Twig_Environment
+	 */
+	public static function parser()
+	{
+		if (empty(static::$_parser))
+		{
+			parent::parser();
+			
+			// Register Haml twig supports
+			static::$_parser->addExtension(new MtHaml\Support\Twig\Extension());
+				// Store MtHaml environment
+			static::$_environment	= new MtHaml\Environment('twig', \Config::get('parser.View_HamlTwig.environment'));
+
+			return static::$_parser;
+		}
+		return parent::parser();
+	}
+}
+
+// end of file hamltwig.php

--- a/config/parser.php
+++ b/config/parser.php
@@ -27,6 +27,7 @@ return array(
 	'extensions' => array(
 		'php'       => 'View',
 		'twig'      => 'View_Twig',
+		'mthaml'    =>  array('class' => 'View_HamlTwig', 'extension' => 'twig'),
 		'mustache'  => 'View_Mustache',
 		'md'        => 'View_Markdown',
 		'dwoo'      => array('class' => 'View_Dwoo', 'extension' => 'tpl'),
@@ -72,6 +73,23 @@ return array(
 		),
 		'extensions' => array(
 			'Twig_Fuel_Extension'
+		),
+	),
+	
+	// HamlTwig with MtHaml https://github.com/arnaud-lb/MtHaml
+	// Twig configuration is grabbed from 'View_Twig' config key
+	// Packagist url: https://packagist.org/packages/mthaml/mthaml
+	// Uses > 1.1.1 (Master branch ATM)
+	// ------------------------------------------------------------------------
+	'View_HamlTwig' => array(
+		//'include' => APPPATH.'vendor'.DS.'MtHaml'.DS.'Autoloader.php',
+		'auto_encode' => true,
+		'environment' => array(
+			'auto_escaper' => true,
+			'escape_html'	 => true,
+			'escape_attrs' => true,
+			'charset' 		 => 'UTF-8',
+			'format' 		 	 => 'html5',
 		),
 	),
 


### PR DESCRIPTION
Support for hybrid haml/twig throught the MtHaml library. #59
https://github.com/arnaud-lb/MtHaml
Only works with MtHaml > 1.1.1

Example of use:

```
{% haml %}
!!!
%html
    %head
        %title Register
    %body
        %h1 Register
        = form_open(url("submit"))
        = form_input("email")
        = form_close()
```
