### PR TITLE
Alow Asset::find_file usable by twig

### DIFF
--- a/classes/twig/fuel/extension.php
+++ b/classes/twig/fuel/extension.php
@@ -73,6 +73,7 @@ class Twig_Fuel_Extension extends Twig_Extension
 			'asset_js'          => new Twig_Function_Function('Asset::js'),
 			'asset_img'         => new Twig_Function_Function('Asset::img'),
 			'asset_render'      => new Twig_Function_Function('Asset::render'),
+			'asset_find_file'   => new Twig_Function_Function('Asset::find_file'),
 
 			'html_anchor'       => new Twig_Function_Function('Html::anchor'),
 			'input_get'         => new Twig_Function_Function('Input::get'),


### PR DESCRIPTION
Allow for example to add a favicon to your page : {{ base_url() ~ asset_find_file("favicon.png", "img") }}
