### PR TITLE
Workaround for issue #77

### DIFF
--- a/classes/view/twig.php
+++ b/classes/view/twig.php
@@ -98,9 +98,8 @@ class View_Twig extends \View
 
 		// Twig Environment
 		$twig_env_conf = \Config::get('parser.View_Twig.environment', array('optimizer' => -1));
-		static::$_parser = new Twig_Environment(static::$_parser_loader, $twig_env_conf);
-        $mods = \Module::loaded();
-        foreach (\Config::get('parser.View_Twig.extensions') as $ext)
+
+	        foreach (\Config::get('parser.View_Twig.extensions') as $ext)
 		{
 			static::$_parser->addExtension(new $ext());
 		}

--- a/classes/view/twig.php
+++ b/classes/view/twig.php
@@ -45,8 +45,15 @@ class View_Twig extends \View
 		$views_paths = \Config::get('parser.View_Twig.views_paths', array(APPPATH . 'views'));
 		array_unshift($views_paths, pathinfo($file, PATHINFO_DIRNAME));
 		static::$_parser_loader = new Twig_Loader_Filesystem($views_paths);
+        if(!empty(\Module::loaded())){
+            $mods = \Module::loaded();
+            foreach ($mods as $mod) {
+                $m_name = explode('modules/',$mod);
+                static::$_parser_loader->addPath($mod.'views/',rtrim($m_name[1],'/'));
+            }
+        }
 
-		if ( ! empty($global_data))
+        if ( ! empty($global_data))
 		{
 			foreach ($global_data as $key => $value)
 			{
@@ -92,8 +99,8 @@ class View_Twig extends \View
 		// Twig Environment
 		$twig_env_conf = \Config::get('parser.View_Twig.environment', array('optimizer' => -1));
 		static::$_parser = new Twig_Environment(static::$_parser_loader, $twig_env_conf);
-
-		foreach (\Config::get('parser.View_Twig.extensions') as $ext)
+        $mods = \Module::loaded();
+        foreach (\Config::get('parser.View_Twig.extensions') as $ext)
 		{
 			static::$_parser->addExtension(new $ext());
 		}


### PR DESCRIPTION
After initially trying to create an extension to work around the problem in the issue, I've been pointed to a more feasible approach on StackOverflow.

What I am doing here is adding each module in a name space, which allows to use {% extends @module/template.twig %} to extend/include specific module templates instead of the first one to be encountered along the view paths..
